### PR TITLE
Pin docker-compose versions to the time of release

### DIFF
--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.8.*
+
 FROM docker:1.12
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.10.*
+
 FROM docker:1.13
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/17.03/Dockerfile
+++ b/17.03/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.11.*
+
 FROM docker:17.03
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/17.06/Dockerfile
+++ b/17.06/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.15.*
+
 FROM docker:17.06
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/17.09/Dockerfile
+++ b/17.09/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.16.*
+
 FROM docker:17.09
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/17.12/Dockerfile
+++ b/17.12/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.18.*
+
 FROM docker:17.12
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.18.*
+
 FROM docker:17
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/18.02/Dockerfile
+++ b/18.02/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.19.*
+
 FROM docker:18.02
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=1.19.*
+
 FROM docker:18
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 [![GitHub stars](https://img.shields.io/github/stars/tmaier/docker-compose.svg?style=social&label=Star)](https://github.com/tmaier/docker-compose)
 
 This docker image installs docker-compose on top of the `docker` image.
-This is very usefull for CI pipelines, which leverage "Docker in Docker".
+This is very useful for CI pipelines, which leverage "Docker in Docker".
 
 ## Docker versions supported
 
 There are versions based on different docker versions, e.g. `latest`, `17.06`, `17.03` and `1.13`.
+
+docker-compose matches the latest minor version available when the docker release was made. Eg, `17.06` includes docker-compose 1.15.0. The `latest` tag always includes the latest docker-compose build.
 
 Please open an issue or a pull request (preferred) [at GitHub](https://github.com/tmaier/docker-compose), if a version is missing.
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,5 +1,7 @@
+ARG COMPOSE_VERSION=
+
 FROM docker:latest
 MAINTAINER Tobias Maier <tobias.maier@baucloud.com>
 
 RUN apk add --no-cache py-pip
-RUN pip install docker-compose
+RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"


### PR DESCRIPTION
Otherwise the docker-compose version is the latest available at time of build, which may not be compatible or expected. The latest `COMPOSE_VERSION` can be taken by setting the argument blank (or leaving it as is in the case of `latest`).

The extra `${COMPOSE_VERSION:+==}` is because pip errors out with just `docker-compose==`

Fixes #4