### PR TITLE
Installs pip for python3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM docker:${DOCKER_VERSION}
 ARG COMPOSE_VERSION=
 ARG DOCKER_VERSION
 
-RUN apk add --no-cache py-pip
-RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"
+RUN apk add --no-cache py3-pip
+RUN pip3 install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"
 
 LABEL \
   org.opencontainers.image.authors="Tobias Maier <tobias.maier@baucloud.com>" \


### PR DESCRIPTION
This worked for me, in case you want to use python3 after you do a docker-compose up in the GitLab CI docker in docker. It was a niche use-case where we wanted to run a test suite after using docker compose up.