### PR TITLE
Change: use python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ FROM docker:${DOCKER_VERSION}
 ARG COMPOSE_VERSION=
 ARG DOCKER_VERSION
 
-RUN apk add --no-cache py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
-RUN pip install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"
+RUN apk add --no-cache py3-pip
+RUN apk add --virtual build-dependencies python3-dev libffi-dev openssl-dev gcc libc-dev make \
+  && pip3 install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}" \
+  && apk del build-dependencies
 
 LABEL \
   org.opencontainers.image.authors="Tobias Maier <tobias.maier@baucloud.com>" \


### PR DESCRIPTION
also delete unneeded dependencies afterwards, savings are 200MB+

This uses Python 3's better yaml parser. Py2's yaml parser does not like some valid yaml in some cases.

Also.. who uses Python 2.7 anyway ;)