### PR TITLE
Returns make and adds alpine-sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ ARG COMPOSE_VERSION=
 ARG DOCKER_VERSION
 
 RUN apk add --no-cache py3-pip python3
-RUN apk add --no-cache --virtual build-dependencies python3-dev libffi-dev openssl-dev gcc libc-dev make \
-  && pip3 install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}" \
-  && apk del build-dependencies
+RUN apk add --no-cache alpine-sdk
+RUN apk add --no-cache \
+  python3-dev libffi-dev openssl-dev \
+  && pip3 install "docker-compose${COMPOSE_VERSION:+==}${COMPOSE_VERSION}"
 
 LABEL \
   org.opencontainers.image.authors="Tobias Maier <tobias.maier@baucloud.com>" \


### PR DESCRIPTION
After https://github.com/tmaier/docker-compose/pull/23 make and other important things were removed. Saving space is very important, but saving time on passing the CI is equally important. The need to install these components back increases the build time in CI. The weight of the image with the alpine-sdk package again became approximately 550mb.